### PR TITLE
fix(dist): webpack now includes correct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
 	"name": "es6-tween",
 	"version": "1.11.3",
 	"description": "ES6 implementation of amazing tween.js",
-	"main": "dist/Tween.js",
-	"module": "src/Tween.js",
+	"main": "dist/TWEEN.js",
 	"directories": {
 		"example": "examples"
 	},


### PR DESCRIPTION
The `module` property was causing webpack to include the raw es6 version and crashing iOS Safari,
removing it forces webpack to include the transpiled version from dist.