### PR TITLE
fix TypeScript imports via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "cdn": "bundled/Tween.min.js",
   "main": "bundled/Tween.js",
   "module": "src/index.js",
+  "types": "src/index.d.js",
   "directories": {
     "example": "examples"
   },


### PR DESCRIPTION
Fixes #46 by adding a "types" declaration in package.json, as explained in http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html.