### PR TITLE
Mark TWEEN.update()'s time parameter as optional.

### DIFF
--- a/ts/core.ts
+++ b/ts/core.ts
@@ -173,14 +173,14 @@ const remove = (tween: any): void => {
 
 /**
  * Updates global tweens by given time
- * @param {number|Time} time Timestamp
+ * @param {number|Time=} time Timestamp
  * @param {Boolean=} preserve Prevents tween to be removed after finish
  * @memberof TWEEN
  * @example
  * TWEEN.update(500)
  */
 
-const update = (time: number, preserve?: boolean): boolean => {
+const update = (time?: number, preserve?: boolean): boolean => {
   time = time !== undefined ? time : now();
   if (_autoPlay && isStarted) {
     _tick = _ticker(update);


### PR DESCRIPTION
The code already allowed `time` to be undefined. This commit updates the documentation and typing to match.