### PR TITLE
Fix update loop

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -195,8 +195,16 @@ const update = (time = now(), preserve) => {
   }
 
   let i = 0
-  while (i < _tweens.length) {
+  var length = _tweens.length
+  while (i < length) {
     _tweens[i++].update(time, preserve)
+
+    if (length > _tweens.length) {
+      // The tween has been removed, keep same index
+      i--
+    }
+
+    length = _tweens.length
   }
 
   return true

--- a/test.js
+++ b/test.js
@@ -159,3 +159,36 @@ test('Easing', t => {
   t.not(ElasticInOut(0.6), 0.6, 'Elastic.InOut was not eased as excepted')
   t.log('Elastic.InOut was eased as excepted')
 })
+
+test('Tween update should be run against all tween each time', t => {
+  const order = []
+
+  new Tween({ x: 0 })
+    .to({ x: 100 }, 100)
+    .start(0)
+    .on('complete', () => {
+      order.push(0)
+    })
+  new Tween({ x: 0 })
+    .to({ x: 100 }, 100)
+    .delay(10)
+    .start(0)
+    .on('complete', () => {
+      order.push(1)
+    })
+  new Tween({ x: 0 })
+    .to({ x: 100 }, 100)
+    .delay(20)
+    .start(0)
+    .on('complete', () => {
+      order.push(2)
+    })
+
+  t.plan(1)
+
+  update(0)
+  update(200)
+
+  t.deepEqual(order, [0, 1, 2])
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -190,5 +190,4 @@ test('Tween update should be run against all tween each time', t => {
   update(200)
 
   t.deepEqual(order, [0, 1, 2])
-  t.end()
 })


### PR DESCRIPTION
Hi,

I figured out that the order of `complete` events wasn't properly repsected. 

After dig in, I found that the update loop uses 

```javascript
while ( i < _tweens.length)  {
  _tweens[i++].update( time, preserve)
}
```

The issue is that ` _tweens[i++].update( time, preserve)` can (actually will by default) remove the tween from our `_tweens` meaning we will skip the next index.

I've added a unit test :)