### PR TITLE
[Feature] onRequestTick

### DIFF
--- a/API.md
+++ b/API.md
@@ -48,6 +48,7 @@ const {add, remove, isRunning, autoPlay} = TWEEN
     * [.onTick(fn)](#TWEEN.onTick)
     * [.FrameThrottle([frameCount])](#TWEEN.FrameThrottle)
     * [.autoPlay(state)](#TWEEN.autoPlay)
+    * [.onRequestTick(fn)](#TWEEN.onRequestTick)
     * [.removeAll()](#TWEEN.removeAll)
     * [.get(tween)](#TWEEN.get) ⇒ <code>Tween</code>
     * [.has(tween)](#TWEEN.has) ⇒ <code>Boolean</code>
@@ -543,7 +544,7 @@ TWEEN.FrameThrottle(60)
 <a name="TWEEN.autoPlay"></a>
 
 ### TWEEN.autoPlay(state)
-Runs update loop automaticlly
+Runs update loop automatically
 
 **Kind**: static method of [<code>TWEEN</code>](#TWEEN)  
 
@@ -554,6 +555,23 @@ Runs update loop automaticlly
 **Example**  
 ```js
 TWEEN.autoPlay(true)
+```
+<a name="TWEEN.onRequestTick"></a>
+
+### TWEEN.onRequestTick(fn)
+Add a function called when another animation frame is requested. This is only called when autoPlay is false.
+
+**Kind**: static method of [<code>TWEEN</code>](#TWEEN)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fn | <code>function</code> | Function called when another animation frame is requested |
+
+**Example**  
+```js
+TWEEN.onRequestTick(() => {
+    requestAnimationFrame(TWEEN.update);
+})
 ```
 <a name="TWEEN.removeAll"></a>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "es6-tween",
-  "version": "5.2.2",
+  "name": "@adactive/es6-tween",
+  "version": "5.3.0-alpha.1",
   "description": "ES6 implementation of amazing tween.js",
   "browser": "bundled/Tween.min.js",
   "cdn": "bundled/Tween.min.js",
@@ -54,6 +54,11 @@
   },
   "dependencies": {},
   "standard": {
-    "ignore": ["node_modules", "bundled", "examples", "performance"]
+    "ignore": [
+      "node_modules",
+      "bundled",
+      "examples",
+      "performance"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@adactive/es6-tween",
-  "version": "5.3.0-alpha.1",
+  "name": "es6-tween",
+  "version": "5.2.2",
   "description": "ES6 implementation of amazing tween.js",
   "browser": "bundled/Tween.min.js",
   "cdn": "bundled/Tween.min.js",

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,5 @@
 /* global process */
-import { cancelAnimationFrame, requestAnimationFrame, root } from './shim'
+import { requestAnimationFrame, root } from './shim'
 
 /**
  * Get browser/Node.js current time-stamp
@@ -50,20 +50,18 @@ const now = (function () {
 const _tweens = []
 let isStarted = false
 let _autoPlay = false
-let _tick
 let _onRequestTick = []
 const _ticker = requestAnimationFrame
-const _stopTicker = cancelAnimationFrame
 let emptyFrame = 0
 let powerModeThrottle = 120
 
 const onRequestTick = (fn) => {
-  _onRequestTick.push(fn);
+  _onRequestTick.push(fn)
 }
 
 const _requestTick = () => {
   for (let i = 0; i < _onRequestTick.length; i++) {
-    _onRequestTick[i]();
+    _onRequestTick[i]()
   }
 }
 
@@ -88,10 +86,10 @@ const add = (tween) => {
   emptyFrame = 0
 
   if (_autoPlay && !isStarted) {
-    _tick = _ticker(update)
+    _ticker(update)
     isStarted = true
   } else {
-    _requestTick();
+    _requestTick()
   }
 }
 
@@ -199,7 +197,7 @@ const update = (time = now(), preserve) => {
   }
 
   if (_autoPlay && isStarted) {
-    _tick = _ticker(update)
+    _ticker(update)
   } else {
     _requestTick()
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import {
   has,
   isRunning,
   now,
+  onRequestTick,
+  FrameThrottle,
   Plugins,
   remove,
   removeAll,
@@ -33,6 +35,8 @@ export {
   update,
   autoPlay,
   isRunning,
+  onRequestTick,
+  FrameThrottle,
   Tween,
   Easing,
   Interpolation


### PR DESCRIPTION
Add `TWEEN.onRequestTick` that can be used to notify when another animation frame is needed.

This can be used when autoPlay is false and the user wants on demand animation frame rather than continuous one.

Also, Fix `TWEEN.FrameThrottle` which wasn't expose