### PR TITLE
Fixed link under Installation part.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Starting at `v3`, we provide excluded plugins from core, so our core becomes lig
 
 ## Installation
 
-Download the [library](https://unpkg.com/es6-tween@5.5.2/bundled/Tween.min.js) and include it in your code:
+Download the [library](https://unpkg.com/es6-tween/bundled/Tween.js) and include it in your code:
 
 ```html
-<script src="bundled/Tween.min.js"></script>
+<script src="bundled/Tween.js"></script>
 ```
 
 ### CDN-Hosted version

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Starting at `v3`, we provide excluded plugins from core, so our core becomes lig
 
 ## Installation
 
-Download the [library](https://raw.githubusercontent.com/tweenjs/es6-tween/master/ts/Tween.ts) and include it in your code:
+Download the [library](https://unpkg.com/es6-tween@5.5.2/bundled/Tween.min.js) and include it in your code:
 
 ```html
-<script src="bundled/Tween.js"></script>
+<script src="bundled/Tween.min.js"></script>
 ```
 
 ### CDN-Hosted version


### PR DESCRIPTION
Taken from https://tweenjs.gitbook.io/es6-tween/.