### PR TITLE
Moving outside the null selector condition

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -1,32 +1,34 @@
 export default function (selector, collection, allowRaw) {
-  if (collection) {
-    return !selector
-      ? null
-      : (typeof window !== 'undefined' && selector === window) ||
-        (typeof document !== 'undefined' && selector === document)
-        ? [selector]
-        : typeof selector === 'string'
-          ? !!document.querySelectorAll && document.querySelectorAll(selector)
-          : Array.isArray(selector)
-            ? selector
-            : selector.nodeType
-              ? [selector]
-              : allowRaw
-                ? selector
-                : []
+  if (!selector) {
+    return null
   }
-  return !selector
-    ? null
-    : (typeof window !== 'undefined' && selector === window) ||
-      (typeof document !== 'undefined' && selector === document)
-      ? selector
+
+  const isGlobalScope =
+    (typeof window !== 'undefined' && selector === window) ||
+    (typeof document !== 'undefined' && selector === document)
+
+  if (collection) {
+    return isGlobalScope
+      ? [selector]
       : typeof selector === 'string'
-        ? !!document.querySelector && document.querySelector(selector)
+        ? !!document.querySelectorAll && document.querySelectorAll(selector)
         : Array.isArray(selector)
-          ? selector[0]
+          ? selector
           : selector.nodeType
-            ? selector
+            ? [selector]
             : allowRaw
               ? selector
-              : null
+              : []
+  }
+  return isGlobalScope
+    ? selector
+    : typeof selector === 'string'
+      ? !!document.querySelector && document.querySelector(selector)
+      : Array.isArray(selector)
+        ? selector[0]
+        : selector.nodeType
+          ? selector
+          : allowRaw
+            ? selector
+            : null
 }


### PR DESCRIPTION
A little suggestion, is to move the falsy check of the selector outside the ternary expression. Also, moving the long boolean expression, only for readability purpose